### PR TITLE
docs: add search-content tool documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Search Content Tool**: Real-time web search using Perplexity Sonar models with comprehensive citation support
+  - Five Perplexity models: sonar, sonar-pro, sonar-deep-research, sonar-reasoning, sonar-reasoning-pro
+  - Advanced search modes: web (general), academic (research papers), sec (SEC filings)
+  - Search filters: recency (week/month/year), domain filtering, images, related questions
+  - Reasoning effort control for deep-research model (low/medium/high)
+  - Cost calculation for all Perplexity pricing tiers
+  - Comprehensive test coverage (19 tests) for all search parameters
 - **GPT-5-codex Model Support**: Added `gpt-5-codex` to supported models for code generation, refactoring, debugging, and code explanations
   - Updated configuration schema validation
   - Updated documentation across README, configuration guide, and integration guides


### PR DESCRIPTION
## Summary

Updates documentation for the newly implemented search-content tool (from #24, merged in #28).

## Changes

**README.md:**
- Updated features section to include Perplexity Sonar models and change tool count from four to five
- Added PERPLEXITY_API_KEY to required configuration
- Documented search-content tool with all parameters and examples
- Updated project structure to show perplexity-client.ts and search-content.ts
- Updated tech stack to mention Perplexity Sonar API integration
- Updated test count from 46 to 86 tests

**CHANGELOG.md:**
- Added search-content tool to Unreleased section
- Documented five Perplexity models and their capabilities
- Listed all search modes, filters, and features
- Noted comprehensive test coverage (19 new tests)

## Related Issues

- Closes #24 (already closed by implementation PR #28, this PR completes documentation)

## Test Plan

Documentation changes only. All technical implementation was completed and tested in #28.