### PR TITLE
ci: add check to prevent Claude attribution in commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,17 @@ jobs:
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.sha }}"
 
-          # Check commit messages for Claude attribution (case-insensitive)
-          if git log ${BASE_SHA}..${HEAD_SHA} --pretty=format:"%B" | grep -iE "(co-author|co-authored-by).*claude"; then
+          # Verify git log command succeeds
+          if ! git log ${BASE_SHA}..${HEAD_SHA} --pretty=format:"%B" > /dev/null 2>&1; then
+            echo "❌ Error: Failed to retrieve commit history"
+            exit 1
+          fi
+
+          # Check commit messages for Claude attribution in Git trailer format (case-insensitive)
+          # Matches standard Git trailers like "Co-Authored-By: Claude" or "Author: Claude"
+          if git log ${BASE_SHA}..${HEAD_SHA} --pretty=format:"%B" | grep -iE "^\s*(co-authored-by|authored-by|author):\s*.*claude"; then
             echo "❌ Error: Found Claude attribution in commit messages"
-            echo "Please remove Co-Authored-By: Claude from your commits"
+            echo "Please remove Co-Authored-By: Claude or similar attributions from your commits"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Adds a CI check that automatically fails PRs containing Claude attribution in commit messages.

## Changes

- Modified `.github/workflows/ci.yml` to add attribution check
- Runs only on pull requests
- Scans all commits in the PR for Claude attribution patterns
- Fails with clear error message if found

## Implementation

The check searches for case-insensitive patterns:
- `Co-Author.*Claude`
- `Co-Authored-By.*Claude`

This ensures commits follow project attribution guidelines as specified in user preferences.

## Testing

- ✅ Workflow syntax validated
- ✅ Quality checks passed (lint, format, type-check)
- Will be tested automatically when this PR is opened